### PR TITLE
Update cypress to version 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^3.0.2"
+    "cypress": "^3.3.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION

Enable Cypress 3.3.0 https://docs.cypress.io/guides/references/changelog.html#3-3-0