### PR TITLE
Failure threshold percentage explained

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ For example, the default options we use in `<rootDir>/cypress/support/commands.j
 
 ```js
 addMatchImageSnapshotCommand({
-  failureThreshold: 0.03, // threshold for entire image
+  failureThreshold: 0.03, // 3% threshold for entire image 
   failureThresholdType: 'percent', // percent of image or number of pixels
   customDiffConfig: { threshold: 0.1 }, // threshold for each pixel
   capture: 'viewport', // capture viewport in screenshot


### PR DESCRIPTION
As seen in this issue https://github.com/palmerhq/cypress-image-snapshot/issues/104 the value of `failureThreshold` option could be counterintuitive.

Example:
`failureThreshold: 0.01` is equal to 1% but you could think of it as 0.01%