### PR TITLE
nit: update jest-image-snapshot "4.2.0",

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chalk": "^2.4.1",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",
-    "jest-image-snapshot": "2.8.2",
+    "jest-image-snapshot": "4.2.0",
     "pkg-dir": "^3.0.0",
     "term-img": "^4.0.0"
   },


### PR DESCRIPTION
update `jest-image-snapshot` "4.2.0",
`npm install` warning about `jest-image-snapshot` requires `jest` of this specific version. 

Please review and approve this request. 