### PR TITLE
Fix getting false positives when using Cypress v5+ native retries

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,9 +69,12 @@ export function matchImageSnapshotPlugin({ path: screenshotPath }) {
   const receivedImageBuffer = fs.readFileSync(screenshotPath);
   fs.removeSync(screenshotPath);
 
-  const { dir: screenshotDir, name: snapshotIdentifier } = path.parse(
+  const { dir: screenshotDir, name } = path.parse(
     screenshotPath
   );
+
+  // remove the cypress v5+ native retries suffix from the file name
+  const snapshotIdentifier = name.replace(/ \(attempt [0-9]+\)/, '');
 
   const relativePath = path.relative(screenshotsFolder, screenshotDir);
   const snapshotsDir = customSnapshotsDir


### PR DESCRIPTION
When using native retries that come in Cypress v5+ real image failures are marked as passed on the retries.

This is because cypress names the snapshots as 'filename (attempt X).png (and there is no configuration option to change this)

The fix just removes the ' (attempt X)' suffix from the filename

