### PR TITLE
expand cypress peer dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0 || ^5.0.0 || ^6.0.0"
+    "cypress": ">=4.5.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0"
+    "cypress": "^4.5.0 || ^5.0.0 || ^6.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Expand cypress peer dependency versions to include v5 and v6.

Fixes #168 