### PR TITLE
Support diff Major versions

### DIFF
--- a/.changeset/young-laws-stare.md
+++ b/.changeset/young-laws-stare.md
@@ -1,0 +1,5 @@
+---
+"cypress-image-snapshot": patch
+---
+
+Support diff Major versions

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0 || ^5.x || ^6.x"
+    "cypress": ">=4.5.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0"
+    "cypress": "^4.5.0 || ^5.x || ^6.x"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
With these changes, the plugin will be supported by major versions of Cypress which introduced almost a year ago.
Currently, the new npm version is complaining that the plugin is not compatible with higher versions of cypress.