### PR TITLE
fix(command): prevent executing `Cypress.*`-code before cypress initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 /*.js
 
 .DS_Store
+.idea

--- a/src/command.js
+++ b/src/command.js
@@ -7,12 +7,12 @@
 
 import { MATCH, RECORD } from './constants';
 
-const screenshotsFolder = Cypress.config('screenshotsFolder');
-const updateSnapshots = Cypress.env('updateSnapshots') || false;
-const failOnSnapshotDiff =
-  typeof Cypress.env('failOnSnapshotDiff') === 'undefined';
-
 export function matchImageSnapshotCommand(defaultOptions) {
+  const screenshotsFolder = Cypress.config('screenshotsFolder');
+  const updateSnapshots = Cypress.env('updateSnapshots') || false;
+  const failOnSnapshotDiff =
+    typeof Cypress.env('failOnSnapshotDiff') === 'undefined';
+
   return function matchImageSnapshot(subject, maybeName, commandOptions) {
     const options = {
       ...defaultOptions,


### PR DESCRIPTION
Hi!
I am a user of your plugin.
I try to write my own plugin using your plugin as a basis.
But I have faced with this problem.

**Problem:**
Imagine that you have `plugin.js`-file:
```js
import {
    addMatchImageSnapshotPlugin,
    matchImageSnapshotPlugin,
} from 'cypress-image-snapshot/plugin';

export function tuiAddSnapshotPlugin(on, config) {
    addMatchImageSnapshotPlugin(on, config);
    // ...
    on('after:screenshot', details => {
        // ...
        return matchImageSnapshotPlugin(details);
    })
}
```
And you have this `command.js`-file:
```js
import {addMatchImageSnapshotCommand} from 'cypress-image-snapshot/command';

export function tuiAddMatchImageSnapshotCommand(options) {
    // ... some new logic
    addMatchImageSnapshotCommand(options);
}
```
Finally, everything is wrapped by `index.js`-file:
```js
export * from './command';
export * from './plugin';
```

When you try to import plugin and command from your `index.js` and use it inside your cypress-tests, you will get error:
```
ReferenceError: Cypress is not defined
```
This happens because exporting of the plugin happens earlier than command (when `Cypress` is not yet ready). But some code (the changed lines of this PR) is not isolated by any function scope and we get the error.
My PR will help to solve this problem without changing any logic of your code.